### PR TITLE
feat: Implementar flujo de autenticación con Firebase y Bloc

### DIFF
--- a/lib/data/models/user_model/user_model.dart
+++ b/lib/data/models/user_model/user_model.dart
@@ -5,6 +5,7 @@ class PlayerModel {
     this.scoreTrivia,
     this.scorePattern,
     this.userName,
+    this.userId,
   });
 
   PlayerModel.fromJson(Map<String, Object?> json)
@@ -14,6 +15,7 @@ class PlayerModel {
       scoreTrivia: json['score_trivia'] as int?,
       scorePattern: json['score_pattern'] as int?,
       userName: json['user_name'] as String?,
+      userId: json['userId'] as String?,
     );
 
   final int? scoreMemory;
@@ -21,15 +23,17 @@ class PlayerModel {
   final int? scoreTrivia;
   final int? scorePattern;
   final String? userName;
+  final String? userId;
 
   // Factory to initialize all fields to 0
-  factory PlayerModel.initial() {
+  factory PlayerModel.initial({required String userId, required String userName}) {
     return PlayerModel(
       scoreMemory: 0,
       scorePuzzle: 0,
       scoreTrivia: 0,
       scorePattern: 0,
-      userName: '',
+      userName: userName,
+      userId: userId,
     );
   }
 
@@ -40,6 +44,7 @@ class PlayerModel {
       'score_trivia': scoreTrivia,
       'score_pattern': scorePattern,
       'user_name': userName,
+      'userId': userId,
     };
   }
 }

--- a/lib/data/services/authentication/firebase_auth_service.dart
+++ b/lib/data/services/authentication/firebase_auth_service.dart
@@ -1,0 +1,62 @@
+import 'package:firebase_auth/firebase_auth.dart';
+
+class FirebaseAuthService {
+  final FirebaseAuth _auth;
+
+  // Constructor para permitir la inyección de FirebaseAuth (para pruebas)
+  // y usar la instancia por defecto en producción.
+  FirebaseAuthService({FirebaseAuth? firebaseAuth}) : _auth = firebaseAuth ?? FirebaseAuth.instance;
+
+  // Stream para escuchar los cambios de estado de autenticación
+  Stream<User?> get authStateChanges => _auth.authStateChanges();
+
+  // Obtener el usuario actual
+  User? get currentUser => _auth.currentUser;
+
+  // Iniciar sesión con correo y contraseña
+  Future<UserCredential?> signInWithEmailAndPassword(String email, String password) async {
+    try {
+      UserCredential userCredential = await _auth.signInWithEmailAndPassword(
+        email: email,
+        password: password,
+      );
+      return userCredential;
+    } on FirebaseAuthException catch (e) {
+      // Manejar errores específicos de Firebase Auth aquí si es necesario
+      // Por ejemplo, usuario no encontrado, contraseña incorrecta
+      print('Error de inicio de sesión: ${e.message}');
+      return null;
+    } catch (e) {
+      print('Ocurrió un error inesperado durante el inicio de sesión: $e');
+      return null;
+    }
+  }
+
+  // Registrar un nuevo usuario con correo y contraseña
+  Future<UserCredential?> createUserWithEmailAndPassword(String email, String password) async {
+    try {
+      UserCredential userCredential = await _auth.createUserWithEmailAndPassword(
+        email: email,
+        password: password,
+      );
+      return userCredential;
+    } on FirebaseAuthException catch (e) {
+      // Manejar errores específicos de Firebase Auth aquí si es necesario
+      // Por ejemplo, correo ya en uso, contraseña débil
+      print('Error de registro: ${e.message}');
+      return null;
+    } catch (e) {
+      print('Ocurrió un error inesperado durante el registro: $e');
+      return null;
+    }
+  }
+
+  // Cerrar sesión
+  Future<void> signOut() async {
+    try {
+      await _auth.signOut();
+    } catch (e) {
+      print('Ocurrió un error durante el cierre de sesión: $e');
+    }
+  }
+}

--- a/lib/data/services/firestore/firestore_user_service.dart
+++ b/lib/data/services/firestore/firestore_user_service.dart
@@ -1,0 +1,52 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:alzheimer_games_app/data/models/user_model/user_model.dart'; // Asegúrate que esta ruta sea correcta
+
+class FirestoreUserService {
+  final FirebaseFirestore _db;
+  final String _collectionPath = 'users'; // Nombre de la colección en Firestore
+
+  // Constructor para permitir la inyección de FirebaseFirestore (para pruebas)
+  // y usar la instancia por defecto en producción.
+  FirestoreUserService({FirebaseFirestore? firestore}) : _db = firestore ?? FirebaseFirestore.instance;
+
+  // Crear o actualizar un documento de usuario
+  Future<void> createUserDocument(PlayerModel user) async {
+    try {
+      if (user.userId == null || user.userId!.isEmpty) {
+        throw ArgumentError('El userId no puede ser nulo o vacío.');
+      }
+      await _db.collection(_collectionPath).doc(user.userId).set(user.toJson());
+    } on FirebaseException catch (e) {
+      // Manejar errores específicos de Firestore aquí si es necesario
+      print('Error al crear/actualizar el documento de usuario: ${e.message}');
+      rethrow; // O maneja el error de forma diferente
+    } catch (e) {
+      print('Ocurrió un error inesperado al crear/actualizar el documento de usuario: $e');
+      rethrow; // O maneja el error de forma diferente
+    }
+  }
+
+  // Obtener un documento de usuario
+  Future<PlayerModel?> getUserDocument(String userId) async {
+    try {
+      if (userId.isEmpty) {
+        throw ArgumentError('El userId no puede ser nulo o vacío.');
+      }
+      DocumentSnapshot doc = await _db.collection(_collectionPath).doc(userId).get();
+      if (doc.exists) {
+        return PlayerModel.fromJson(doc.data() as Map<String, dynamic>);
+      } else {
+        // El documento no existe
+        print('No se encontró ningún usuario con el ID: $userId');
+        return null;
+      }
+    } on FirebaseException catch (e) {
+      // Manejar errores específicos de Firestore aquí si es necesario
+      print('Error al obtener el documento de usuario: ${e.message}');
+      return null;
+    } catch (e) {
+      print('Ocurrió un error inesperado al obtener el documento de usuario: $e');
+      return null;
+    }
+  }
+}

--- a/lib/features/bloc/auth_cubit.dart
+++ b/lib/features/bloc/auth_cubit.dart
@@ -1,0 +1,96 @@
+import 'dart:async';
+import 'package:alzheimer_games_app/data/models/user_model/user_model.dart';
+import 'package:alzheimer_games_app/data/services/authentication/firebase_auth_service.dart';
+import 'package:alzheimer_games_app/data/services/firestore/firestore_user_service.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'auth_state.dart'; // Importar los estados definidos
+
+class AuthCubit extends Cubit<AuthState> {
+  final FirebaseAuthService _authService;
+  final FirestoreUserService _userService;
+  StreamSubscription<User?>? _authStateSubscription;
+
+  AuthCubit({
+    required FirebaseAuthService authService,
+    required FirestoreUserService userService,
+  })  : _authService = authService,
+        _userService = userService,
+        super(AuthInitial()) {
+    _monitorAuthStateChanges();
+  }
+
+  void _monitorAuthStateChanges() {
+    _authStateSubscription = _authService.authStateChanges.listen((user) {
+      if (user != null) {
+        emit(Authenticated(user));
+      } else {
+        emit(Unauthenticated());
+      }
+    });
+  }
+
+  Future<void> signUp(String email, String password, String userName) async {
+    emit(AuthLoading());
+    try {
+      final userCredential = await _authService.createUserWithEmailAndPassword(email, password);
+      if (userCredential?.user != null) {
+        final newUser = PlayerModel.initial(
+          userId: userCredential!.user!.uid,
+          userName: userName,
+        );
+        await _userService.createUserDocument(newUser);
+        // El Stream _monitorAuthStateChanges se encargará de emitir Authenticated
+      } else {
+        emit(const AuthError('No se pudo crear el usuario.'));
+      }
+    } on FirebaseAuthException catch (e) {
+      emit(AuthError(e.message ?? 'Error de autenticación desconocido.'));
+    } catch (e) {
+      emit(AuthError(e.toString()));
+    }
+  }
+
+  Future<void> signIn(String email, String password) async {
+    emit(AuthLoading());
+    try {
+      final userCredential = await _authService.signInWithEmailAndPassword(email, password);
+      if (userCredential?.user == null) {
+         emit(const AuthError('Credenciales incorrectas o error en el inicio de sesión.'));
+      }
+      // El Stream _monitorAuthStateChanges se encargará de emitir Authenticated si es exitoso
+    } on FirebaseAuthException catch (e) {
+      emit(AuthError(e.message ?? 'Error de autenticación desconocido.'));
+    } catch (e) {
+      emit(AuthError(e.toString()));
+    }
+  }
+
+  Future<void> signOut() async {
+    emit(AuthLoading());
+    try {
+      await _authService.signOut();
+      // El Stream _monitorAuthStateChanges se encargará de emitir Unauthenticated
+    } catch (e) {
+      emit(AuthError(e.toString()));
+    }
+  }
+
+  // Método para verificar el estado actual (puede ser útil al inicio)
+  // Aunque _monitorAuthStateChanges ya hace esto al suscribirse.
+  void checkInitialAuthStatus() {
+    final currentUser = _authService.currentUser; // Asumiendo que FirebaseAuthService tiene un getter para currentUser
+    if (currentUser != null) {
+      emit(Authenticated(currentUser));
+    } else {
+      emit(Unauthenticated());
+    }
+  }
+
+
+  @override
+  Future<void> close() {
+    _authStateSubscription?.cancel();
+    return super.close();
+  }
+}

--- a/lib/features/bloc/auth_state.dart
+++ b/lib/features/bloc/auth_state.dart
@@ -1,0 +1,39 @@
+import 'package:firebase_auth/firebase_auth.dart'; // Necesario para el tipo User
+import 'package:equatable/equatable.dart';
+
+// Clase base abstracta para los estados de autenticación
+abstract class AuthState extends Equatable {
+  const AuthState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+// Estado inicial: aún no se ha determinado el estado de autenticación
+class AuthInitial extends AuthState {}
+
+// Estado de carga: se está procesando una operación de autenticación (login, signup)
+class AuthLoading extends AuthState {}
+
+// Estado autenticado: el usuario ha iniciado sesión correctamente
+class Authenticated extends AuthState {
+  final User user; // Información del usuario de Firebase
+
+  const Authenticated(this.user);
+
+  @override
+  List<Object?> get props => [user];
+}
+
+// Estado no autenticado: el usuario no está conectado o ha cerrado sesión
+class Unauthenticated extends AuthState {}
+
+// Estado de error: ocurrió un problema durante la autenticación
+class AuthError extends AuthState {
+  final String message; // Mensaje de error
+
+  const AuthError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/screens/auth/auth_wrapper_screen.dart
+++ b/lib/features/screens/auth/auth_wrapper_screen.dart
@@ -1,0 +1,55 @@
+import 'package:alzheimer_games_app/features/screens/auth/login_screen.dart';
+import 'package:alzheimer_games_app/features/screens/landing/landing_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:alzheimer_games_app/features/bloc/auth_cubit.dart';
+import 'package:alzheimer_games_app/features/bloc/auth_state.dart';
+
+class AuthWrapperScreen extends StatelessWidget {
+  const AuthWrapperScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<AuthCubit, AuthState>(
+      builder: (context, state) {
+        if (state is AuthInitial || state is AuthLoading) {
+          return const Scaffold(
+            body: Center(
+              child: CircularProgressIndicator(),
+            ),
+          );
+        } else if (state is Authenticated) {
+          // Usuario autenticado, mostrar LandingScreen
+          // return const LandingScreen(); // O navegar si es preferible
+          // Para mantener la consistencia con la navegación de rutas:
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (ModalRoute.of(context)?.settings.name != '/landing') {
+               Navigator.of(context).pushReplacementNamed('/landing');
+            }
+          });
+          // Muestra un loader mientras se redirige para evitar parpadeos
+          return const Scaffold(body: Center(child: CircularProgressIndicator()));
+
+
+        } else if (state is Unauthenticated || state is AuthError) {
+          // Usuario no autenticado o error, mostrar LoginScreen
+          // return const LoginScreen(); // O navegar si es preferible
+          // Para mantener la consistencia con la navegación de rutas:
+           WidgetsBinding.instance.addPostFrameCallback((_) {
+             if (ModalRoute.of(context)?.settings.name != '/login') {
+              Navigator.of(context).pushReplacementNamed('/login');
+             }
+           });
+          // Muestra un loader mientras se redirige para evitar parpadeos
+          return const Scaffold(body: Center(child: CircularProgressIndicator()));
+        }
+        // Estado por defecto o inesperado
+        return const Scaffold(
+          body: Center(
+            child: Text('Error inesperado en el flujo de autenticación.'),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/screens/auth/login_screen.dart
+++ b/lib/features/screens/auth/login_screen.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:alzheimer_games_app/features/bloc/auth_cubit.dart';
+import 'package:alzheimer_games_app/features/bloc/auth_state.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  // bool _isLoading = false; // Eliminado
+  // final FirebaseAuthService _authService = FirebaseAuthService(); // Eliminado
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _login() async {
+    if (_formKey.currentState!.validate()) {
+      context.read<AuthCubit>().signIn(
+            _emailController.text.trim(),
+            _passwordController.text.trim(),
+          );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Iniciar Sesión'),
+      ),
+      body: BlocConsumer<AuthCubit, AuthState>(
+        listener: (context, state) {
+          if (state is Authenticated) {
+            ScaffoldMessenger.of(context).hideCurrentSnackBar();
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Inicio de sesión exitoso.')),
+            );
+            // La navegación a '/landing' ya la maneja AuthWrapperScreen.
+          } else if (state is AuthError) {
+            ScaffoldMessenger.of(context).hideCurrentSnackBar();
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text('Error: ${state.message}')),
+            );
+          }
+        },
+        builder: (context, state) {
+          final isLoading = state is AuthLoading;
+
+          return Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Form(
+              key: _formKey,
+              child: ListView(
+                children: <Widget>[
+                  TextFormField(
+                    controller: _emailController,
+                    decoration: const InputDecoration(labelText: 'Correo Electrónico'),
+                    keyboardType: TextInputType.emailAddress,
+                    enabled: !isLoading,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Por favor ingresa tu correo.';
+                  }
+                  if (!value.contains('@')) {
+                    return 'Por favor ingresa un correo válido.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(labelText: 'Contraseña'),
+                obscureText: true,
+                    enabled: !isLoading,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Por favor ingresa tu contraseña.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 32),
+                  isLoading
+                  ? const Center(child: CircularProgressIndicator())
+                  : ElevatedButton(
+                      onPressed: _login,
+                      child: const Text('Iniciar Sesión'),
+                    ),
+              TextButton(
+                    onPressed: isLoading ? null : () {
+                  Navigator.of(context).pushNamed('/signup');
+                },
+                child: const Text('¿No tienes una cuenta? Regístrate'),
+              )
+            ],
+          ),
+        ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/screens/auth/signup_screen.dart
+++ b/lib/features/screens/auth/signup_screen.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:alzheimer_games_app/features/bloc/auth_cubit.dart';
+import 'package:alzheimer_games_app/features/bloc/auth_state.dart';
+// PlayerModel no es necesario aquí directamente si AuthCubit lo maneja.
+// import 'package:alzheimer_games_app/data/models/user_model/user_model.dart'; 
+// FirebaseAuthService y FirestoreUserService no son necesarios aquí.
+// import 'package:alzheimer_games_app/data/services/authentication/firebase_auth_service.dart';
+// import 'package:alzheimer_games_app/data/services/firestore/firestore_user_service.dart';
+
+
+class SignUpScreen extends StatefulWidget {
+  const SignUpScreen({super.key});
+
+  @override
+  State<SignUpScreen> createState() => _SignUpScreenState();
+}
+
+class _SignUpScreenState extends State<SignUpScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+
+  // Eliminadas las instancias de servicios y _isLoading
+  // final FirebaseAuthService _authService = FirebaseAuthService();
+  // final FirestoreUserService _userService = FirestoreUserService();
+  // bool _isLoading = false;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _emailController.dispose();
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _signUp() async {
+    if (_formKey.currentState!.validate()) {
+      if (_passwordController.text != _confirmPasswordController.text) {
+        ScaffoldMessenger.of(context).hideCurrentSnackBar();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Las contraseñas no coinciden.')),
+        );
+        return;
+      }
+      context.read<AuthCubit>().signUp(
+            _emailController.text.trim(),
+            _passwordController.text.trim(),
+            _nameController.text.trim(),
+          );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Crear Cuenta'),
+      ),
+      body: BlocConsumer<AuthCubit, AuthState>(
+        listener: (context, state) {
+          if (state is Authenticated) {
+            ScaffoldMessenger.of(context).hideCurrentSnackBar();
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Registro exitoso.')),
+            );
+            // AuthWrapperScreen se encargará de la redirección.
+          } else if (state is AuthError) {
+            ScaffoldMessenger.of(context).hideCurrentSnackBar();
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text('Error en el registro: ${state.message}')),
+            );
+          }
+        },
+        builder: (context, state) {
+          final isLoading = state is AuthLoading;
+
+          return Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Form(
+              key: _formKey,
+              child: ListView(
+                children: <Widget>[
+                  TextFormField(
+                    controller: _nameController,
+                    decoration: const InputDecoration(labelText: 'Nombre Completo'),
+                    enabled: !isLoading,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Por favor ingresa tu nombre.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(labelText: 'Correo Electrónico'),
+                keyboardType: TextInputType.emailAddress,
+                enabled: !isLoading,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Por favor ingresa tu correo.';
+                  }
+                  if (!value.contains('@')) {
+                    return 'Por favor ingresa un correo válido.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(labelText: 'Contraseña'),
+                obscureText: true,
+                enabled: !isLoading,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Por favor ingresa tu contraseña.';
+                  }
+                  if (value.length < 6) {
+                    return 'La contraseña debe tener al menos 6 caracteres.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _confirmPasswordController,
+                decoration: const InputDecoration(labelText: 'Confirmar Contraseña'),
+                obscureText: true,
+                enabled: !isLoading,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Por favor confirma tu contraseña.';
+                  }
+                  if (value != _passwordController.text) {
+                    return 'Las contraseñas no coinciden.';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 32),
+              isLoading
+                  ? const Center(child: CircularProgressIndicator())
+                  : ElevatedButton(
+                      onPressed: _signUp,
+                      child: const Text('Registrarse'),
+                    ),
+              TextButton(
+                onPressed: isLoading ? null : () {
+                  Navigator.of(context).pushNamed('/login');
+                },
+                child: const Text('¿Ya tienes una cuenta? Inicia Sesión'),
+              ),
+            ],
+          ),
+        ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,12 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:provider/provider.dart';
 import 'data/repositories/question_repository.dart';
 import 'features/bloc/bottom_nav_cubit.dart';
+import 'package:alzheimer_games_app/features/bloc/auth_cubit.dart';
+import 'package:alzheimer_games_app/data/services/authentication/firebase_auth_service.dart';
+import 'package:alzheimer_games_app/data/services/firestore/firestore_user_service.dart';
+import 'package:alzheimer_games_app/features/screens/auth/auth_wrapper_screen.dart';
+import 'package:alzheimer_games_app/features/screens/auth/login_screen.dart';
+import 'package:alzheimer_games_app/features/screens/auth/signup_screen.dart';
 import 'features/screens/games/trivia/trivia_view_model.dart';
 import 'features/screens/screens.dart';
 void main() async {
@@ -21,6 +27,12 @@ void main() async {
       providers: [
         BlocProvider<BottomNavCubit>(
           create: (context) => BottomNavCubit(),
+        ),
+        BlocProvider<AuthCubit>(
+          create: (context) => AuthCubit(
+            authService: FirebaseAuthService(), // Instanciar el servicio
+            userService: FirestoreUserService(),  // Instanciar el servicio
+          )..checkInitialAuthStatus(), // Opcional: llamar para un estado inicial síncrono si es necesario
         ),
       ],
       child: const MyApp(),
@@ -37,9 +49,12 @@ class MyApp extends StatelessWidget {
       title: 'Alzheimer Games',
       debugShowCheckedModeBanner: false,
 
-      initialRoute: '/landing',
+      initialRoute: '/', // Changed initialRoute
       routes: {
+        '/': (context) => const AuthWrapperScreen(), // Nueva ruta inicial
         '/landing': (context) => const LandingScreen(),
+        '/login': (context) => const LoginScreen(),   // Nueva ruta para Login
+        '/signup': (context) => const SignUpScreen(), // Nueva ruta para SignUp
         '/home': (context) => const HomeScreen(),
         '/puzzle': (context) => const SlidePuzzleScreen(),
         '/memorama': (context) => const MemoramaScreen(),
@@ -47,14 +62,17 @@ class MyApp extends StatelessWidget {
           create: (context) => TriviaViewModel(
             questionRepository: QuestionRepository(firestoreService: FirestoreService(FirebaseFirestore.instance)),
             firestoreService: FirestoreService(FirebaseFirestore.instance),
-            authService: AuthService(FirebaseAuth.instance),
+            authService: AuthService(FirebaseAuth.instance), // Kept original services for TriviaViewModel
           ),
           child: const TriviaScreen(),
         ),
         '/encaje_figura': (context) => const FiguraEncajeScreen(),
       },
       onGenerateRoute: (settings) {
-        return MaterialPageRoute(builder: (context) => const HomeScreen());
+        // It's good practice to have a fallback, but with AuthWrapperScreen, 
+        // unhandled routes might be less common.
+        // Consider navigating to AuthWrapperScreen or a dedicated error screen.
+        return MaterialPageRoute(builder: (context) => const AuthWrapperScreen());
       },
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,14 +36,16 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_bloc: ^9.1.0
+  equatable: ^2.0.5 # Added equatable
   get_it: ^8.0.3
   google_fonts: ^6.1.0
   iconly: ^1.0.1
   provider: ^6.1.4
-  mocktail: ^1.0.4
 
 dev_dependencies:
   flutter_lints: ^5.0.0
+  mocktail: ^1.0.4 # Moved mocktail here
+  bloc_test: ^9.1.7 # Added bloc_test
   flutter_test:
     sdk: flutter
 

--- a/test/data/services/authentication/firebase_auth_service_test.dart
+++ b/test/data/services/authentication/firebase_auth_service_test.dart
@@ -1,0 +1,134 @@
+import 'package:alzheimer_games_app/data/services/authentication/firebase_auth_service.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+// Mocks
+class MockFirebaseAuth extends Mock implements FirebaseAuth {}
+class MockUserCredential extends Mock implements UserCredential {}
+class MockUser extends Mock implements User {}
+
+void main() {
+  late FirebaseAuthService authService;
+  late MockFirebaseAuth mockFirebaseAuth;
+  late MockUser mockUser; // Para el currentUser y authStateChanges
+  late MockUserCredential mockUserCredential; // Para los retornos de signIn/createUser
+
+  setUp(() {
+    mockFirebaseAuth = MockFirebaseAuth();
+    authService = FirebaseAuthService(firebaseAuth: mockFirebaseAuth);
+    mockUser = MockUser();
+    mockUserCredential = MockUserCredential();
+
+    // Configuración por defecto para UserCredential y User si es necesario
+    // when(() => mockUserCredential.user).thenReturn(mockUser);
+    // when(() => mockUser.uid).thenReturn('test_uid');
+  });
+
+  group('FirebaseAuthService Tests', () {
+    
+    group('currentUser', () {
+      test('debería devolver User cuando _auth.currentUser no es null', () {
+        when(() => mockFirebaseAuth.currentUser).thenReturn(mockUser);
+        expect(authService.currentUser, mockUser);
+      });
+
+      test('debería devolver null cuando _auth.currentUser es null', () {
+        when(() => mockFirebaseAuth.currentUser).thenReturn(null);
+        expect(authService.currentUser, null);
+      });
+    });
+
+    group('authStateChanges', () {
+      test('debería emitir User cuando el stream de Firebase emite User', () {
+        when(() => mockFirebaseAuth.authStateChanges()).thenAnswer((_) => Stream.value(mockUser));
+        expect(authService.authStateChanges, emits(mockUser));
+      });
+
+      test('debería emitir null cuando el stream de Firebase emite null', () {
+         when(() => mockFirebaseAuth.authStateChanges()).thenAnswer((_) => Stream.value(null));
+        expect(authService.authStateChanges, emits(null));
+      });
+    });
+    
+    group('signInWithEmailAndPassword', () {
+      const testEmail = 'test@example.com';
+      const testPassword = 'password';
+
+      test('debería devolver UserCredential en caso de éxito', () async {
+        when(() => mockFirebaseAuth.signInWithEmailAndPassword(email: testEmail, password: testPassword))
+            .thenAnswer((_) async => mockUserCredential);
+        
+        final result = await authService.signInWithEmailAndPassword(testEmail, testPassword);
+        expect(result, mockUserCredential);
+      });
+
+      test('debería devolver null y loguear error en FirebaseAuthException', () async {
+        when(() => mockFirebaseAuth.signInWithEmailAndPassword(email: any(named: 'email'), password: any(named: 'password')))
+            .thenThrow(FirebaseAuthException(code: 'user-not-found'));
+        
+        final result = await authService.signInWithEmailAndPassword(testEmail, testPassword);
+        expect(result, null);
+        // Aquí podrías añadir expectAsync para verificar el log si tienes un logger inyectado
+        // verify(() => logger.e(any(that: contains('Error de inicio de sesión')))).called(1); // Ejemplo
+      });
+
+       test('debería devolver null y loguear error en Exception general', () async {
+        when(() => mockFirebaseAuth.signInWithEmailAndPassword(email: any(named: 'email'), password: any(named: 'password')))
+            .thenThrow(Exception('Error genérico'));
+        
+        final result = await authService.signInWithEmailAndPassword(testEmail, testPassword);
+        expect(result, null);
+        // verify(() => logger.e(any(that: contains('Ocurrió un error inesperado')))).called(1); // Ejemplo
+      });
+    });
+
+    group('createUserWithEmailAndPassword', () {
+      const testEmail = 'newuser@example.com';
+      const testPassword = 'newpassword';
+
+      test('debería devolver UserCredential en caso de éxito', () async {
+        when(() => mockFirebaseAuth.createUserWithEmailAndPassword(email: testEmail, password: testPassword))
+            .thenAnswer((_) async => mockUserCredential);
+        
+        final result = await authService.createUserWithEmailAndPassword(testEmail, testPassword);
+        expect(result, mockUserCredential);
+      });
+
+      test('debería devolver null y loguear error en FirebaseAuthException', () async {
+        when(() => mockFirebaseAuth.createUserWithEmailAndPassword(email: any(named: 'email'), password: any(named: 'password')))
+            .thenThrow(FirebaseAuthException(code: 'email-already-in-use'));
+        
+        final result = await authService.createUserWithEmailAndPassword(testEmail, testPassword);
+        expect(result, null);
+        // Verificar log
+      });
+
+       test('debería devolver null y loguear error en Exception general', () async {
+        when(() => mockFirebaseAuth.createUserWithEmailAndPassword(email: any(named: 'email'), password: any(named: 'password')))
+            .thenThrow(Exception('Error genérico de creación'));
+        
+        final result = await authService.createUserWithEmailAndPassword(testEmail, testPassword);
+        expect(result, null);
+        // Verificar log
+      });
+    });
+
+    group('signOut', () {
+      test('debería completarse sin errores en caso de éxito', () async {
+        when(() => mockFirebaseAuth.signOut()).thenAnswer((_) async {}); // Completa normalmente
+        
+        await expectLater(authService.signOut(), completes);
+      });
+
+      test('debería completarse y loguear error en caso de Exception', () async {
+         when(() => mockFirebaseAuth.signOut()).thenThrow(Exception('Error al cerrar sesión'));
+
+        // El método signOut en el servicio no relanza la excepción, solo la loguea.
+        // Por lo tanto, la prueba debe esperar que se complete, no que lance un error.
+        await expectLater(authService.signOut(), completes);
+        // Verificar el log si es posible
+      });
+    });
+  });
+}

--- a/test/data/services/firestore/firestore_user_service_test.dart
+++ b/test/data/services/firestore/firestore_user_service_test.dart
@@ -1,0 +1,133 @@
+import 'package:alzheimer_games_app/data/models/user_model/user_model.dart';
+import 'package:alzheimer_games_app/data/services/firestore/firestore_user_service.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+// Mocks
+class MockFirebaseFirestore extends Mock implements FirebaseFirestore {}
+class MockCollectionReference extends Mock implements CollectionReference<Map<String, dynamic>> {}
+class MockDocumentReference extends Mock implements DocumentReference<Map<String, dynamic>> {}
+class MockDocumentSnapshot extends Mock implements DocumentSnapshot<Map<String, dynamic>> {}
+
+void main() {
+  late FirestoreUserService firestoreUserService;
+  late MockFirebaseFirestore mockFirestore;
+  late MockCollectionReference mockCollectionReference;
+  late MockDocumentReference mockDocumentReference;
+  late MockDocumentSnapshot mockDocumentSnapshot;
+
+  setUp(() {
+    mockFirestore = MockFirebaseFirestore();
+    mockCollectionReference = MockCollectionReference();
+    mockDocumentReference = MockDocumentReference();
+    mockDocumentSnapshot = MockDocumentSnapshot();
+    
+    // Inyectar el mock de FirebaseFirestore
+    firestoreUserService = FirestoreUserService(firestore: mockFirestore); 
+
+    // Configuración general de los mocks para que devuelvan otros mocks
+    when(() => mockFirestore.collection(any())).thenReturn(mockCollectionReference);
+    when(() => mockCollectionReference.doc(any())).thenReturn(mockDocumentReference);
+  });
+
+  final testPlayerModel = PlayerModel(
+    userId: 'testUserId',
+    userName: 'Test User',
+    scoreMemory: 0,
+    scorePattern: 0,
+    scorePuzzle: 0,
+    scoreTrivia: 0,
+  );
+  final testPlayerData = testPlayerModel.toJson();
+
+  group('FirestoreUserService Tests', () {
+    group('createUserDocument', () {
+      test('debería completarse exitosamente cuando los datos son válidos', () async {
+        when(() => mockDocumentReference.set(testPlayerData)).thenAnswer((_) async {});
+        
+        await expectLater(firestoreUserService.createUserDocument(testPlayerModel), completes);
+        verify(() => mockDocumentReference.set(testPlayerData)).called(1);
+      });
+
+      test('debería lanzar ArgumentError si userId es nulo', () async {
+        final playerWithNullId = PlayerModel(userId: null, userName: 'Test');
+        // expect is used for synchronous exceptions
+        expect(() => firestoreUserService.createUserDocument(playerWithNullId), throwsArgumentError);
+        verifyNever(() => mockDocumentReference.set(any()));
+      });
+      
+      test('debería lanzar ArgumentError si userId está vacío', () async {
+        final playerWithEmptyId = PlayerModel(userId: '', userName: 'Test');
+        expect(() => firestoreUserService.createUserDocument(playerWithEmptyId), throwsArgumentError);
+        verifyNever(() => mockDocumentReference.set(any()));
+      });
+
+      test('debería relanzar FirebaseException en error de Firestore', () async {
+        final exception = FirebaseException(plugin: 'test', message: 'Firestore error');
+        when(() => mockDocumentReference.set(testPlayerData)).thenThrow(exception);
+        
+        expect(() => firestoreUserService.createUserDocument(testPlayerModel), throwsA(isA<FirebaseException>()));
+      });
+
+      test('debería relanzar Exception en error general', () async {
+        final exception = Exception('Generic error');
+        when(() => mockDocumentReference.set(testPlayerData)).thenThrow(exception);
+
+        expect(() => firestoreUserService.createUserDocument(testPlayerModel), throwsA(isA<Exception>()));
+      });
+    });
+
+    group('getUserDocument', () {
+      test('debería devolver PlayerModel si el documento existe', () async {
+        when(() => mockDocumentSnapshot.exists).thenReturn(true);
+        when(() => mockDocumentSnapshot.data()).thenReturn(testPlayerData);
+        when(() => mockDocumentReference.get()).thenAnswer((_) async => mockDocumentSnapshot);
+        
+        final result = await firestoreUserService.getUserDocument('testUserId');
+        
+        expect(result, isA<PlayerModel>());
+        expect(result?.userId, testPlayerModel.userId);
+        expect(result?.userName, testPlayerModel.userName);
+      });
+
+      test('debería devolver null si el documento no existe', () async {
+        when(() => mockDocumentSnapshot.exists).thenReturn(false);
+        when(() => mockDocumentReference.get()).thenAnswer((_) async => mockDocumentSnapshot);
+        
+        final result = await firestoreUserService.getUserDocument('nonExistentUserId');
+        expect(result, null);
+      });
+      
+      // La prueba para userId nulo no es aplicable directamente a la firma del método que espera String.
+      // El chequeo de isEmpty es el relevante para ArgumentError.
+      // test('debería lanzar ArgumentError si userId es nulo', () async { ... });
+
+      test('debería lanzar ArgumentError si userId está vacío', () async {
+        // El método getUserDocument ahora toma String userId, no String? userId
+        // Por lo tanto, no se puede pasar null directamente.
+        // El error se captura si la cadena está vacía.
+        expect(() => firestoreUserService.getUserDocument(''), throwsArgumentError);
+        verifyNever(() => mockDocumentReference.get());
+      });
+
+      test('debería devolver null y loguear en FirebaseException', () async {
+        final exception = FirebaseException(plugin: 'test', message: 'Firestore error');
+        when(() => mockDocumentReference.get()).thenThrow(exception);
+        
+        final result = await firestoreUserService.getUserDocument('testUserId');
+        expect(result, null);
+        // Verificar log si es posible (requeriría inyectar un logger y mockearlo)
+      });
+
+      test('debería devolver null y loguear en Exception general', () async {
+        final exception = Exception('Generic error');
+        when(() => mockDocumentReference.get()).thenThrow(exception);
+
+        final result = await firestoreUserService.getUserDocument('testUserId');
+        expect(result, null);
+        // Verificar log si es posible
+      });
+    });
+  });
+}

--- a/test/features/bloc/auth_cubit_test.dart
+++ b/test/features/bloc/auth_cubit_test.dart
@@ -1,0 +1,300 @@
+import 'package:alzheimer_games_app/data/models/user_model/user_model.dart';
+import 'package:alzheimer_games_app/data/services/authentication/firebase_auth_service.dart';
+import 'package:alzheimer_games_app/data/services/firestore/firestore_user_service.dart';
+import 'package:alzheimer_games_app/features/bloc/auth_cubit.dart';
+import 'package:alzheimer_games_app/features/bloc/auth_state.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'dart:async';
+
+
+// Mocks
+class MockFirebaseAuthService extends Mock implements FirebaseAuthService {}
+class MockFirestoreUserService extends Mock implements FirestoreUserService {}
+class MockUser extends Mock implements User {
+  @override
+  final String uid = 'test_uid'; // Necesario para PlayerModel.initial y verificaciones
+  @override
+  final String email = 'test@example.com'; // Añadido por si es necesario
+}
+class MockUserCredential extends Mock implements UserCredential {}
+
+
+void main() {
+  late AuthCubit authCubit;
+  late MockFirebaseAuthService mockAuthService;
+  late MockFirestoreUserService mockUserService;
+  late MockUser mockUser;
+  late MockUserCredential mockUserCredential;
+  
+  // Un controlador de stream para simular authStateChanges
+  late StreamController<User?> authStateController;
+
+  setUp(() {
+    mockAuthService = MockFirebaseAuthService();
+    mockUserService = MockFirestoreUserService();
+    mockUser = MockUser();
+    mockUserCredential = MockUserCredential();
+    authStateController = StreamController<User?>();
+
+    // Configuración por defecto para los mocks
+    when(() => mockAuthService.authStateChanges).thenAnswer((_) => authStateController.stream);
+    when(() => mockAuthService.currentUser).thenReturn(null); // Estado inicial por defecto: no logueado
+    when(() => mockUserCredential.user).thenReturn(mockUser);
+
+
+    authCubit = AuthCubit(
+      authService: mockAuthService,
+      userService: mockUserService,
+    );
+  });
+
+  tearDown(() {
+    authStateController.close();
+    authCubit.close();
+  });
+
+  group('AuthCubit Tests', () {
+    // Test para el estado inicial del AuthCubit
+    // Se espera que el estado sea AuthInitial justo después de la creación,
+    // antes de que cualquier evento del stream authStateChanges sea procesado.
+    test('estado inicial debería ser AuthInitial', () {
+      // Es importante que el stream no emita nada síncronamente durante la creación del AuthCubit
+      // para que esta prueba pase consistentemente.
+      expect(authCubit.state, AuthInitial());
+    });
+
+    blocTest<AuthCubit, AuthState>(
+      'debería emitir [Authenticated] cuando authStateChanges emite un User',
+      setUp: () {
+        // Asegura que el estado inicial no sea Authenticated por currentUser
+        when(() => mockAuthService.currentUser).thenReturn(null); 
+        // Re-crear el cubit aquí o asegurar que el `act` sea el primer emisor del stream
+        // El AuthCubit ya está creado en el setUp general, y su stream está escuchando.
+      },
+      build: () => authCubit, // authCubit ya está escuchando authStateController.stream
+      act: (cubit) => authStateController.add(mockUser),
+      expect: () => [Authenticated(mockUser)],
+    );
+
+    blocTest<AuthCubit, AuthState>(
+      'debería emitir [Unauthenticated] cuando authStateChanges emite null',
+       setUp: () {
+        // Para simular un cambio de Authenticated a Unauthenticated,
+        // primero simulamos que el usuario estaba autenticado.
+        when(() => mockAuthService.currentUser).thenReturn(mockUser);
+        // Recreamos el AuthCubit para que _monitorAuthStateChanges coja este currentUser
+        // o podríamos emitir un usuario en el stream primero.
+        // El cubit del setUp general ya está creado con currentUser siendo null.
+        // Para esta prueba específica, es mejor controlar el flujo de estados.
+        
+        // Opción 1: Recrear el cubit después de cambiar currentUser (más limpio para el setup)
+        // authCubit = AuthCubit(authService: mockAuthService, userService: mockUserService);
+        // Esto haría que el estado inicial del cubit (después de procesar currentUser) sea Authenticated.
+        
+        // Opción 2: Emitir un User primero, luego null (más realista para el flujo)
+        // No se necesita setUp adicional si el authCubit del setUp general se usa.
+        // El estado inicial del cubit del setUp general será Unauthenticated (si checkInitialAuthStatus se llama o el stream emite null)
+        // o AuthInitial.
+        // Si el estado inicial es AuthInitial, y luego emitimos mockUser, luego null:
+        // Esperaríamos: [Authenticated(mockUser), Unauthenticated()]
+        // Si el estado inicial ya es Unauthenticated (porque currentUser es null y el stream no ha emitido User):
+        // Esperaríamos: [Unauthenticated()] si el stream emite null directamente.
+      },
+      build: () => authCubit, // Usamos el cubit del setUp general.
+      act: (cubit) {
+        //authStateController.add(mockUser); // Opcional: para asegurar que estaba Authenticated
+        authStateController.add(null); // Simula logout o que el stream emite null
+      },
+      // Si el estado inicial del cubit ya era Unauthenticated (currentUser=null), y el stream emite null,
+      // el estado no cambiará si ya es Unauthenticated.
+      // Si el AuthCubit comienza en AuthInitial, y el stream emite null, entonces espera [Unauthenticated()].
+      // Si queremos probar el cambio de Authenticated -> Unauthenticated:
+      // expect: () => [Authenticated(mockUser), Unauthenticated()]
+      // Para ello, el `act` debería ser:
+      // act: (cubit) {
+      //   authStateController.add(mockUser);
+      //   authStateController.add(null);
+      // }
+      // Dado que la prueba anterior cubre User -> Authenticated, esta puede cubrir null -> Unauthenticated
+      expect: () => [Unauthenticated()],
+    );
+    
+    group('checkInitialAuthStatus', () {
+        blocTest<AuthCubit, AuthState>(
+        'debería emitir [Authenticated] si currentUser no es null',
+        setUp: () {
+            when(() => mockAuthService.currentUser).thenReturn(mockUser);
+            // El stream no debe emitir nada que interfiera.
+        },
+        // Construir un nuevo cubit para esta prueba específica es más aislado.
+        build: () => AuthCubit(authService: mockAuthService, userService: mockUserService),
+        act: (cubit) => cubit.checkInitialAuthStatus(), 
+        expect: () => [Authenticated(mockUser)],
+        );
+
+        blocTest<AuthCubit, AuthState>(
+        'debería emitir [Unauthenticated] si currentUser es null',
+        setUp: () {
+            when(() => mockAuthService.currentUser).thenReturn(null);
+        },
+        build: () => AuthCubit(authService: mockAuthService, userService: mockUserService),
+        act: (cubit) => cubit.checkInitialAuthStatus(),
+        expect: () => [Unauthenticated()],
+        );
+    });
+
+
+    group('signUp', () {
+      const testEmail = 'test@example.com';
+      const testPassword = 'password';
+      const testName = 'Test User';
+
+      blocTest<AuthCubit, AuthState>(
+        'éxito: emite [AuthLoading], luego Authenticated (via stream)',
+        setUp: () {
+          when(() => mockAuthService.createUserWithEmailAndPassword(testEmail, testPassword))
+              .thenAnswer((_) async => mockUserCredential); // mockUserCredential.user es mockUser
+          when(() => mockUserService.createUserDocument(any(that: isA<PlayerModel>())))
+              .thenAnswer((_) async {});
+        },
+        build: () => authCubit,
+        act: (cubit) async {
+          await cubit.signUp(testEmail, testPassword, testName);
+          // Simular que Firebase Auth emite el nuevo usuario después del registro exitoso
+          authStateController.add(mockUser); 
+        },
+        expect: () => [AuthLoading(), Authenticated(mockUser)],
+        verify: (_) {
+          verify(() => mockAuthService.createUserWithEmailAndPassword(testEmail, testPassword)).called(1);
+          verify(() => mockUserService.createUserDocument(any(that: isA<PlayerModel>()
+              .having((p) => p.userName, 'userName', testName)
+              .having((p) => p.userId, 'userId', 'test_uid')))).called(1);
+        },
+      );
+
+      blocTest<AuthCubit, AuthState>(
+        'falla (AuthService devuelve null UserCredential): emite [AuthLoading, AuthError]',
+        setUp: () {
+          when(() => mockAuthService.createUserWithEmailAndPassword(testEmail, testPassword))
+              .thenAnswer((_) async => null); 
+        },
+        build: () => authCubit,
+        act: (cubit) => cubit.signUp(testEmail, testPassword, testName),
+        expect: () => [AuthLoading(), const AuthError('No se pudo crear el usuario.')],
+      );
+      
+      blocTest<AuthCubit, AuthState>(
+        'falla (AuthService lanza FirebaseAuthException): emite [AuthLoading, AuthError]',
+        setUp: () {
+          final exception = FirebaseAuthException(code: 'email-already-in-use', message: 'Email en uso');
+          when(() => mockAuthService.createUserWithEmailAndPassword(testEmail, testPassword))
+              .thenThrow(exception);
+        },
+        build: () => authCubit,
+        act: (cubit) => cubit.signUp(testEmail, testPassword, testName),
+        expect: () => [AuthLoading(), AuthError(exception.message ?? 'Error de autenticación desconocido.')],
+      );
+
+      blocTest<AuthCubit, AuthState>(
+        'falla (UserService lanza Exception): emite [AuthLoading, AuthError]',
+        setUp: () {
+          final exception = Exception('Firestore error');
+          when(() => mockAuthService.createUserWithEmailAndPassword(testEmail, testPassword))
+              .thenAnswer((_) async => mockUserCredential);
+          when(() => mockUserService.createUserDocument(any(that: isA<PlayerModel>())))
+              .thenThrow(exception);
+        },
+        build: () => authCubit,
+        act: (cubit) => cubit.signUp(testEmail, testPassword, testName),
+        expect: () => [AuthLoading(), AuthError(exception.toString())],
+      );
+    });
+
+    group('signIn', () {
+      const testEmail = 'test@example.com';
+      const testPassword = 'password';
+
+      blocTest<AuthCubit, AuthState>(
+        'éxito: emite [AuthLoading], luego Authenticated (via stream)',
+        setUp: () {
+          when(() => mockAuthService.signInWithEmailAndPassword(testEmail, testPassword))
+              .thenAnswer((_) async => mockUserCredential);
+        },
+        build: () => authCubit,
+        act: (cubit) async {
+          await cubit.signIn(testEmail, testPassword);
+          // Simular que Firebase Auth emite el usuario después del login
+          authStateController.add(mockUser);
+        },
+        expect: () => [AuthLoading(), Authenticated(mockUser)],
+        verify: (_) {
+          verify(() => mockAuthService.signInWithEmailAndPassword(testEmail, testPassword)).called(1);
+        },
+      );
+
+      blocTest<AuthCubit, AuthState>(
+        'falla (AuthService devuelve null UserCredential): emite [AuthLoading, AuthError]',
+        setUp: () {
+          when(() => mockAuthService.signInWithEmailAndPassword(testEmail, testPassword))
+              .thenAnswer((_) async => null);
+        },
+        build: () => authCubit,
+        act: (cubit) => cubit.signIn(testEmail, testPassword),
+        expect: () => [AuthLoading(), const AuthError('Credenciales incorrectas o error en el inicio de sesión.')],
+      );
+
+      blocTest<AuthCubit, AuthState>(
+        'falla (AuthService lanza FirebaseAuthException): emite [AuthLoading, AuthError]',
+        setUp: () {
+          final exception = FirebaseAuthException(code: 'user-not-found', message: 'Usuario no encontrado');
+          when(() => mockAuthService.signInWithEmailAndPassword(testEmail, testPassword))
+              .thenThrow(exception);
+        },
+        build: () => authCubit,
+        act: (cubit) => cubit.signIn(testEmail, testPassword),
+        expect: () => [AuthLoading(), AuthError(exception.message ?? 'Error de autenticación desconocido.')],
+      );
+    });
+
+    group('signOut', () {
+      blocTest<AuthCubit, AuthState>(
+        'éxito: emite [AuthLoading], luego Unauthenticated (via stream)',
+        setUp: () {
+          when(() => mockAuthService.signOut()).thenAnswer((_) async {});
+           // Simular que el cubit estaba en estado Authenticated
+          when(() => mockAuthService.currentUser).thenReturn(mockUser);
+          authCubit = AuthCubit(authService: mockAuthService, userService: mockUserService);
+          // Forzar el estado inicial a Authenticated para esta prueba
+          authStateController.add(mockUser); 
+        },
+        build: () => authCubit,
+        act: (cubit) async {
+          await cubit.signOut();
+          // Simular que Firebase Auth emite null después del logout
+          authStateController.add(null);
+        },
+        // El primer Authenticated es por el setUp.
+        // Luego AuthLoading por signOut, luego Unauthenticated por el stream.
+        expect: () => [Authenticated(mockUser), AuthLoading(), Unauthenticated()],
+        verify: (_) {
+          verify(() => mockAuthService.signOut()).called(1);
+        },
+      );
+
+
+       blocTest<AuthCubit, AuthState>(
+        'falla (AuthService lanza Exception): emite [AuthLoading, AuthError]',
+        setUp: () {
+          final exception = Exception('Logout error');
+          when(() => mockAuthService.signOut()).thenThrow(exception);
+        },
+        build: () => authCubit,
+        act: (cubit) => cubit.signOut(),
+        expect: () => [AuthLoading(), AuthError(exception.toString())],
+      );
+    });
+  });
+}


### PR DESCRIPTION
Se añade la funcionalidad completa de inicio de sesión y registro de usuarios utilizando Firebase Authentication y Firestore.

Principales cambios:
- Se crea `FirebaseAuthService` para interactuar con Firebase Authentication (login, registro, logout, stream de estado de autenticación).
- Se crea `FirestoreUserService` para gestionar documentos de usuario en Firestore (crear y obtener información del perfil del jugador).
- Se modifica `PlayerModel` para incluir `userId` y se actualizan sus métodos de serialización.
- Se implementan `LoginScreen` y `SignUpScreen` como interfaces de usuario para la autenticación.
- Se introduce `AuthWrapperScreen` para gestionar la redirección entre las pantallas de autenticación y el contenido principal de la aplicación basándose en el estado de autenticación del usuario.
- Se integra `AuthCubit` para la gestión centralizada del estado de autenticación, manejando los estados (Initial, Loading, Authenticated, Unauthenticated, Error) y la lógica de negocio relacionada.
- Se actualiza `main.dart` para proveer `AuthCubit` globalmente y se definen las nuevas rutas de autenticación.
- Se añaden pruebas unitarias para `FirebaseAuthService`, `FirestoreUserService`, y `AuthCubit` para asegurar la fiabilidad de la lógica de autenticación y gestión de datos.
- Se ajustan los constructores de los servicios para permitir la inyección de dependencias, facilitando las pruebas.