### PR TITLE
Fix: Ensure GetIt ViewModels are registered on startup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'data/core/inject.dart';
 import 'package:provider/provider.dart';
 import 'data/repositories/question_repository.dart';
 import 'features/bloc/bottom_nav_cubit.dart';
@@ -22,6 +23,7 @@ void main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
+  await setupInjection();
   runApp(
     MultiBlocProvider(
       providers: [


### PR DESCRIPTION
The application was failing to register ViewModels (e.g., PatternViewModel, MemoramaViewModel, PuzzleViewModel) with the GetIt service locator because the `setupInjection()` function was not being called during application initialization. This resulted in "Bad state: GetIt: Object/factory is not registered" errors when trying to access these ViewModels in various games.

This commit fixes the issue by:
1. Importing `setupInjection` into `lib/main.dart`.
2. Calling `await setupInjection()` in the `main()` function after Firebase initialization and before `runApp()`.

This ensures all necessary dependencies are registered and available application-wide, resolving the runtime errors in the affected games.