### PR TITLE
feat: Cargar puntajes desde Firebase al iniciar los juegos

### DIFF
--- a/lib/features/screens/games/memorama/memorama_screen.dart
+++ b/lib/features/screens/games/memorama/memorama_screen.dart
@@ -25,18 +25,27 @@ class _MemoramaScreenState extends State<MemoramaScreen> with TickerProviderStat
   @override
   void initState() {
     super.initState();
-    _viewModel = GetIt.I<MemoramaViewModel>(); // Initialize ViewModel
-    _generateCards();
+    _initializeGame();
   }
 
-  void _generateCards() {
+  Future<void> _initializeGame() async {
+    _viewModel = GetIt.I<MemoramaViewModel>(); // Initialize ViewModel
+    int initialScore = await _viewModel!.loadInitialScore();
+    _generateCards(initialScore: initialScore);
+  }
+
+  void _generateCards({int initialScore = 0}) {
     List<int> values = List.generate(gridSize * gridSize ~/ 2, (index) => index);
     values = [...values, ...values];
     values.shuffle(Random());
     cards = values.map((value) => CardModel(value: value)).toList();
-    score = 0;
+    score = initialScore;
     selectedIndices.clear();
-    setState(() {});
+    // It's important to check if the widget is still mounted before calling setState,
+    // especially after async operations.
+    if (mounted) {
+      setState(() {});
+    }
   }
 
   void _onCardTap(int index) async {
@@ -91,7 +100,7 @@ class _MemoramaScreenState extends State<MemoramaScreen> with TickerProviderStat
           TextButton(
             onPressed: () {
               Navigator.of(context).pop();
-              _generateCards(); // Reinicia el juego
+              _generateCards(); // Reinicia el juego, score se reinicia a 0 por defecto
             },
             child: const Text('Jugar de Nuevo'),
           ),
@@ -128,7 +137,7 @@ class _MemoramaScreenState extends State<MemoramaScreen> with TickerProviderStat
           IconButton(
             icon: const Icon(Icons.refresh),
             tooltip: 'Reiniciar nivel',
-            onPressed: _generateCards,
+            onPressed: () => _generateCards(), // Reinicia el juego, score se reinicia a 0 por defecto
           ),
         ],
       ),

--- a/lib/features/screens/games/memorama/memorama_view_model.dart
+++ b/lib/features/screens/games/memorama/memorama_view_model.dart
@@ -7,6 +7,16 @@ class MemoramaViewModel with ChangeNotifier {
 
   MemoramaViewModel({required this.userRepository});
 
+  Future<int> loadInitialScore() async {
+    try {
+      PlayerModel player = await userRepository.getCurrentPlayer();
+      return player.scoreMemory ?? 0;
+    } catch (e) {
+      print('Error al cargar puntaje inicial de Memorama: $e');
+      return 0;
+    }
+  }
+
   Future<void> saveGameScore(int newScore) async {
     try {
       // Obtener el PlayerModel actual para no sobrescribir otros puntajes

--- a/lib/features/screens/games/pattern/encaje_figura.dart
+++ b/lib/features/screens/games/pattern/encaje_figura.dart
@@ -49,8 +49,16 @@ class _FiguraEncajeScreenState extends State<FiguraEncajeScreen> {
   @override
   void initState() {
     super.initState();
+    _initializeGameScreen();
+  }
+
+  Future<void> _initializeGameScreen() async {
     _viewModel = GetIt.I<PatternViewModel>(); // Initialize ViewModel
-    _cambiarNivel(nivel);
+    int initialScore = await _viewModel!.loadInitialScore();
+    // Asegurarse de que el widget sigue montado después de la operación asíncrona
+    if (mounted) {
+      _cambiarNivel(nivel, initialScore: initialScore);
+    }
   }
 
   void _nuevaFiguraObjetivo() {
@@ -73,7 +81,7 @@ class _FiguraEncajeScreenState extends State<FiguraEncajeScreen> {
     Future.delayed(const Duration(seconds: 1), _nuevaFiguraObjetivo);
   }
 
-  void _cambiarNivel(String nuevoNivel) {
+  void _cambiarNivel(String nuevoNivel, {int initialScore = 0}) {
     setState(() {
       nivel = nuevoNivel;
       if (nivel == 'Fácil') {
@@ -83,7 +91,7 @@ class _FiguraEncajeScreenState extends State<FiguraEncajeScreen> {
       } else {
         figuras = figurasDificil;
       }
-      score = 0;
+      score = initialScore; // Usar initialScore aquí
       _nuevaFiguraObjetivo();
     });
   }
@@ -114,10 +122,9 @@ class _FiguraEncajeScreenState extends State<FiguraEncajeScreen> {
             icon: const Icon(Icons.refresh),
             tooltip: 'Reiniciar juego',
             onPressed: () {
-              setState(() {
-                score = 0;
-                _nuevaFiguraObjetivo();
-              });
+              // Al reiniciar, el score se establece a 0, y se llama a _cambiarNivel
+              // para regenerar las figuras del nivel actual con score 0.
+              _cambiarNivel(nivel, initialScore: 0);
             },
           )
         ],

--- a/lib/features/screens/games/pattern/pattern_view_model.dart
+++ b/lib/features/screens/games/pattern/pattern_view_model.dart
@@ -7,6 +7,16 @@ class PatternViewModel with ChangeNotifier {
 
   PatternViewModel({required this.userRepository});
 
+  Future<int> loadInitialScore() async {
+    try {
+      PlayerModel player = await userRepository.getCurrentPlayer();
+      return player.scorePattern ?? 0;
+    } catch (e) {
+      print('Error al cargar puntaje inicial de Pattern: $e');
+      return 0;
+    }
+  }
+
   Future<void> saveGameScore(int newScore) async {
     try {
       PlayerModel currentPlayer = await userRepository.getCurrentPlayer();

--- a/lib/features/screens/games/puzzle/puzzle_view_model.dart
+++ b/lib/features/screens/games/puzzle/puzzle_view_model.dart
@@ -15,6 +15,16 @@ class PuzzleViewModel with ChangeNotifier {
 
   PuzzleViewModel({required this.userRepository}); // Added constructor
 
+  Future<int> loadInitialScore() async {
+    try {
+      PlayerModel player = await userRepository.getCurrentPlayer();
+      return player.scorePuzzle ?? 0;
+    } catch (e) {
+      print('Error al cargar puntaje inicial de Puzzle: $e');
+      return 0;
+    }
+  }
+
   Future<void> initialize() async {
     try {
       emitLoading();

--- a/lib/features/screens/games/puzzle/slide_puzzle_screen.dart
+++ b/lib/features/screens/games/puzzle/slide_puzzle_screen.dart
@@ -17,14 +17,25 @@ class _SlidePuzzleScreenState extends State<SlidePuzzleScreen> {
   final List<int> gridOptions = [3, 4, 5];
   int finalScore = 0;
   bool isCompleted = false;
+  int highestOrLastPuzzleScore = 0; // Added state variable
 
   PuzzleViewModel? _viewModel; // ViewModel instance
 
   @override
   void initState() {
     super.initState();
+    _initializeGameScreen();
+  }
+
+  Future<void> _initializeGameScreen() async {
     _viewModel = GetIt.I<PuzzleViewModel>(); // Initialize ViewModel
-    _initializePuzzle();
+    if (_viewModel != null) {
+      highestOrLastPuzzleScore = await _viewModel!.loadInitialScore();
+    }
+    // Ensure the widget is still mounted before calling setState or other methods
+    if (mounted) {
+      _initializePuzzle();
+    }
   }
 
   void _initializePuzzle() {
@@ -45,9 +56,15 @@ class _SlidePuzzleScreenState extends State<SlidePuzzleScreen> {
     if (const ListEquality().equals(tiles, solvedTiles)) {
       setState(() {
         isCompleted = true;
-        finalScore = 100;
+        finalScore = 100; // Or any other logic to determine the score
+        // Save score and update local highest score
+        _viewModel?.saveGameScore(finalScore);
+        if (finalScore > highestOrLastPuzzleScore) { // Update if current finalScore is better (though it's fixed here)
+          highestOrLastPuzzleScore = finalScore;
+        }
+        // For simplicity, as per instructions, we can just update it
+        // highestOrLastPuzzleScore = finalScore; 
       });
-      _viewModel?.saveGameScore(finalScore); // Save score after solving
       // Optionally, disable further moves or show a dialog
     }
   }
@@ -152,8 +169,11 @@ class _SlidePuzzleScreenState extends State<SlidePuzzleScreen> {
           Padding(
             padding: const EdgeInsets.all(16.0),
             child: Text(
-              isCompleted ? '¡Resuelto! Puntaje: $finalScore (Movimientos: $score)' : 'Movimientos: $score',
+              isCompleted 
+                  ? '¡Resuelto! Puntaje: $finalScore (Movimientos: $score)\nMejor Puntaje: $highestOrLastPuzzleScore' 
+                  : 'Movimientos: $score\nMejor Puntaje: $highestOrLastPuzzleScore',
               style: const TextStyle(fontSize: 24, color: Colors.black),
+              textAlign: TextAlign.center,
             ),
           ),
           Expanded(

--- a/lib/features/screens/games/trivia/trivia_screen.dart
+++ b/lib/features/screens/games/trivia/trivia_screen.dart
@@ -20,10 +20,27 @@ class _TriviaScreenState extends State<TriviaScreen> {
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       viewModel?.initialize();
+      // Listen to changes in viewModel to update highestTriviaScore
+      viewModel?.addListener(_updateHighestScoreFromViewModel);
     });
   }
 
+  void _updateHighestScoreFromViewModel() {
+    if (mounted && viewModel?.playerModel?.scoreTrivia != null) {
+      setState(() {
+        highestTriviaScore = viewModel!.playerModel!.scoreTrivia ?? 0;
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    viewModel?.removeListener(_updateHighestScoreFromViewModel);
+    super.dispose();
+  }
+
   int score = 0;
+  int highestTriviaScore = 0; // Added state variable
   bool answered = false;
   int? selectedAnswer;
 
@@ -48,8 +65,17 @@ class _TriviaScreenState extends State<TriviaScreen> {
   }
 
   void _showFinalDialog() {
-    // Guardar el puntaje de la sesión actual
+    // Guardar el puntaje de la sesión actual (la lógica de si es mayor está en el VM)
     viewModel?.saveGameScore(score);
+
+    // Actualizar el highestTriviaScore local si el score actual es mayor
+    if (score > highestTriviaScore) {
+      if (mounted) {
+        setState(() {
+          highestTriviaScore = score;
+        });
+      }
+    }
 
     showDialog(
       context: context,
@@ -135,7 +161,10 @@ class _TriviaScreenState extends State<TriviaScreen> {
             }),
             const SizedBox(height: 30),
             Text('Puntaje de la partida: $score',
-            style: const TextStyle(fontSize: 22))
+                style: const TextStyle(fontSize: 22)),
+            const SizedBox(height: 10),
+            Text('Mejor Puntaje Trivia: $highestTriviaScore',
+                style: const TextStyle(fontSize: 20, color: Colors.black54)),
           ],
         ),
       ),

--- a/lib/features/screens/games/trivia/trivia_view_model.dart
+++ b/lib/features/screens/games/trivia/trivia_view_model.dart
@@ -35,16 +35,24 @@ class TriviaViewModel with ChangeNotifier {
   final FirestoreService firestoreService;
   final AuthService authService;
 
-  Future<void> saveGameScore(int newScore) async { // Added saveGameScore method
+  Future<void> saveGameScore(int newScore) async {
     try {
       PlayerModel currentPlayer = await userRepository.getCurrentPlayer();
-      await userRepository.updateUser(
-        scoreTrivia: newScore,
-        scoreMemory: currentPlayer.scoreMemory,
-        scorePattern: currentPlayer.scorePattern,
-        scorePuzzle: currentPlayer.scorePuzzle,
-      );
-      print('Puntaje de Trivia guardado: $newScore');
+      int currentTriviaScore = currentPlayer.scoreTrivia ?? 0;
+
+      if (newScore > currentTriviaScore) {
+        await userRepository.updateUser(
+          scoreTrivia: newScore,
+          scoreMemory: currentPlayer.scoreMemory,
+          scorePattern: currentPlayer.scorePattern,
+          scorePuzzle: currentPlayer.scorePuzzle,
+        );
+        playerModel?.scoreTrivia = newScore; // Update local model
+        notifyListeners(); // Notify UI of change
+        print('Puntaje de Trivia actualizado y guardado: $newScore');
+      } else {
+        print('Puntaje de Trivia no guardado, el nuevo puntaje ($newScore) no es mayor que el actual ($currentTriviaScore).');
+      }
     } catch (e) {
       print('Error al guardar puntaje de Trivia: $e');
     }


### PR DESCRIPTION
Se implementó la funcionalidad para que los puntajes de los juegos (Memorama, Patrones, Puzzle, Trivia) se carguen desde Firebase al momento de abrir cada juego.

Cambios realizados:

- Memorama y Patrones:
  - El puntaje almacenado en Firebase se carga como el puntaje inicial de la partida.
  - Reiniciar la partida o cambiar de nivel/cuadrícula reinicia el puntaje de la sesión actual a 0.

- Puzzle:
  - El `scorePuzzle` de Firebase se carga y muestra como "Mejor Puntaje".
  - El contador de movimientos de la partida actual siempre inicia en 0.
  - El puntaje se guarda en Firebase si es mejor que el anterior.

- Trivia:
  - El `scoreTrivia` de Firebase se carga y muestra como "Mejor Puntaje Trivia".
  - El puntaje de la sesión de juego actual siempre inicia en 0.
  - El puntaje de la partida se guarda en Firebase solo si es mayor que el puntaje almacenado.

- ViewModels:
  - Se añadieron métodos `loadInitialScore()` a los ViewModels de Memorama, Patrones y Puzzle.
  - Se ajustó la lógica de carga y guardado en `TriviaViewModel`.

Esto asegura que tu progreso se tenga en cuenta al iniciar los juegos, evitando que los puntajes se reinicien a cero incorrectamente.